### PR TITLE
2 connection management

### DIFF
--- a/dist/actions.js
+++ b/dist/actions.js
@@ -129,14 +129,18 @@ var unregister = exports.unregister = function unregister(registration) {
  * @param {Array} args - An array of arguments.
  * @param {object} kwargs - An object of keyword arguments.
  * @param {object} options - An object of options.
+ * @param {object} resultAction - (optional) An action to be dispatched on call success.
+ * @param {object} errorAction - (optional) An action to be dispatched on call error.
  * @return {object} redux action
  */
-var call = exports.call = function call(procedure, args, kwargs, options) {
+var call = exports.call = function call(procedure, args, kwargs, options, resultAction, errorAction) {
   return {
     type: types.CALL,
     procedure: procedure,
     args: args,
     kwargs: kwargs,
-    options: options
+    options: options,
+    resultAction: resultAction,
+    errorAction: errorAction
   };
 };

--- a/dist/middleware.js
+++ b/dist/middleware.js
@@ -9,6 +9,8 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
                                                                                                                                                                                                                                                                    */
 
 
+exports.default = autobahnMiddlewareFactory;
+
 var _autobahn = require('autobahn');
 
 var _types = require('./types');
@@ -45,13 +47,13 @@ var disconnected = function disconnected() {
  * Returns a redux action with type CONNECTION_OPENED and the given session object
  * @function connectionOpened
  * @memberof redux-autobahn:middleware
- * @param {object} session - The session object for the opened connection.
+ * @param {object} connection - The object for the opened connection.
  * @return {object} redux action
  */
-var connectionOpened = function connectionOpened(session) {
+var connectionOpened = function connectionOpened(connection) {
   return {
     type: types.CONNECTION_OPENED,
-    session: session
+    session: connection.session
   };
 };
 
@@ -267,14 +269,14 @@ var result = function result(value) {
 };
 
 /**
- * Returns a boolean that represents if the session exists and is open, therefore it is connected
+ * Returns a boolean that represents if the session for the connection exists and is open, therefore it is connected
  * @function isConnected
  * @memberof redux-autobahn:middleware
- * @param  {object} session  the session object
- * @return {boolean}         returns true if the session exists and is open
+ * @param  {object} connection  the connection object
+ * @return {boolean}         returns true if the session for the connection exists and is open
  */
-var isConnected = function isConnected(session) {
-  return session && session.isOpen;
+var isConnected = function isConnected(connection) {
+  return connection && connection.isOpen;
 };
 
 /**
@@ -293,21 +295,20 @@ var getSubscription = function getSubscription(action) {
  * @function handleAction
  * @memberof redux-autobahn:middleware
  * @param  {object} connection  the connection object
- * @param  {object} session     the session object
  * @param  {function} dispatch  the dispatch function
  * @param  {function} next      the next function
  * @param  {object} action      the redux action
  */
-var handleAction = function handleAction(connection, session, dispatch, next, action) {
+var handleAction = function handleAction(connection, dispatch, next, action) {
   switch (action.type) {
     case types.OPEN_CONNECTION:
-      return isConnected(session) ? dispatch(connected()) : connection.open();
+      return isConnected(connection) ? dispatch(connected()) : connection.open();
 
     case types.CLOSE_CONNECTION:
-      return !isConnected(session) ? dispatch(disconnected()) : connection.close();
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.close();
 
     case types.SUBSCRIBE:
-      return !isConnected(session) ? dispatch(disconnected()) : session.subscribe(action.topic, function (args, kwargs, details) {
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.session.subscribe(action.topic, function (args, kwargs, details) {
         dispatch(event(action.topic, args, kwargs, details));
       }).then(function (subscription) {
         dispatch(subscribed(subscription));
@@ -316,38 +317,44 @@ var handleAction = function handleAction(connection, session, dispatch, next, ac
       });
 
     case types.UNSUBSCRIBE:
-      return !isConnected(session) ? dispatch(disconnected()) : session.unsubscribe(getSubscription(action)).then(function (success) {
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.session.unsubscribe(getSubscription(action)).then(function (success) {
         if (success) dispatch(unsubscribed(action.subscription));else unsubscribeError('Failed to unsubscribe');
       }, function (err) {
         dispatch(unsubscribeError(err));
       });
 
     case types.PUBLISH:
-      return !isConnected(session) ? dispatch(disconnected()) : session.publish(action.topic, action.args, action.kwargs, _extends({}, action.options, { acknowledge: true })).then(function (pub) {
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.session.publish(action.topic, action.args, action.kwargs, _extends({}, action.options, { acknowledge: true })).then(function (pub) {
         dispatch(published(pub, action.topic, action.args, action.kwargs, action.options));
       }, function (err) {
         dispatch(publishError(err));
       });
 
     case types.REGISTER:
-      return !isConnected(session) ? dispatch(disconnected()) : session.register(action.procedure, action.endpoint, action.options).then(function (reg) {
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.session.register(action.procedure, action.endpoint, action.options).then(function (reg) {
         dispatch(registered(reg));
       }, function (err) {
         dispatch(registerError(err));
       });
 
     case types.UNREGISTER:
-      return !isConnected(session) ? dispatch(disconnected()) : session.unregister(action.registration).then(function () {
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.session.unregister(action.registration).then(function () {
         dispatch(unregistered(action.registration));
       }, function (err) {
         dispatch(unregisterError(err));
       });
 
     case types.CALL:
-      return !isConnected(session) ? dispatch(disconnected()) : session.call(action.procedure, action.args, action.kwargs, action.options).then(function (res) {
-        dispatch(result(res));
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.session.call(action.procedure, action.args, action.kwargs, action.options).then(function (res) {
+        if (action.resultAction) {
+          return dispatch(action.resultAction(res));
+        }
+        return dispatch(result(res));
       }, function (err) {
-        dispatch(callError(err));
+        if (action.errorAction) {
+          return dispatch(action.errorAction(err));
+        }
+        return dispatch(callError(err));
       });
 
     default:
@@ -369,39 +376,58 @@ var assert = function assert(assertion, message) {
   }
 };
 
-/**
- * Creates the middleware that dispatches opened and closed connection actions and handles actions
- * @function createMiddleware
- * @memberof redux-autobahn:middleware
- * @param  {Connection} connection  the connection object
- */
-var createMiddleware = function createMiddleware(connection) {
-  assert(connection && typeof connection.open === 'function' && typeof connection.close === 'function', 'autobahn.Connection required');
+function autobahnMiddlewareFactory() {
+  var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      connection = _ref.connection;
 
-  return function (_ref) {
-    var dispatch = _ref.dispatch;
+  function autobahnMiddleware(_ref2) {
+    var dispatch = _ref2.dispatch;
 
-    var session = null;
+    /**
+     * Sets the passed connection for the middleware that dispatches opened and closed connection actions and handles actions
+     * @function setConnection
+     * @memberof redux-autobahn:middleware
+     * @param  {Connection} newConnection  the connection object
+     */
+    autobahnMiddleware.setConnection = function (newConnection) {
+      assert(newConnection && typeof newConnection.open === 'function' && typeof newConnection.close === 'function', 'autobahn.Connection required');
 
-    /* eslint-disable no-param-reassign */
-    connection.onopen = function (s) {
-      session = s;
+      if (autobahnMiddleware._connection) {
+        // close the existing connection
+        autobahnMiddleware.closeConnection('newConnection', 'new connection has been set');
+      }
 
-      dispatch(connectionOpened(session));
+      newConnection.onopen = function (s) {
+        dispatch(connectionOpened(newConnection));
+      };
+
+      newConnection.onclose = function () {
+        autobahnMiddleware._connection = null;
+        dispatch(connectionClosed());
+      };
+
+      autobahnMiddleware._connection = newConnection;
     };
 
-    connection.onclose = function () {
-      session = null;
-
-      dispatch(connectionClosed());
+    /**
+     * Closes the current autobahn connection
+     * @function closeConnection
+     * @memberof redux-autobahn:middleware
+     * @param  {string} reason  (optional) a WAMP URI providing a closing reason to the server side (e.g. 'com.myapp.close.signout'). default is `wamp.goodbye.normal`
+     * @param  {string} message  human-readable closing message
+     */
+    autobahnMiddleware.closeConnection = function (reason, message) {
+      autobahnMiddleware.close(reason, message);
     };
+
+    if (connection) autobahnMiddleware.setConnection(connection);
 
     return function (next) {
       return function (action) {
-        return handleAction(connection, session, dispatch, next, action);
+        handleAction(autobahnMiddleware._connection, dispatch, next, action);
       };
     };
-  };
-};
+  }
 
-exports.default = createMiddleware;
+  return autobahnMiddleware;
+}

--- a/dist/middleware.test.js
+++ b/dist/middleware.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
 var _autobahn = require('autobahn');
 
 var _middleware = require('./middleware');
@@ -19,16 +23,40 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var createTestConnection = function createTestConnection() {
-  return new _autobahn.Connection({
+  var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      session = _ref.session,
+      isOpen = _ref.isOpen;
+
+  var conn = new _autobahn.Connection({
     url: 'ws://localhost:8000/',
     realm: 'realm1'
   });
+  var _session = session || createTestSession();
+  Object.defineProperty(conn, 'session', {
+    get: function get() {
+      return _session;
+    },
+    set: function set(session) {
+      _session = session;
+    }
+  });
+  var _isOpen = isOpen || false;
+  Object.defineProperty(conn, 'isOpen', {
+    get: function get() {
+      return _isOpen;
+    },
+    set: function set(isOpen) {
+      _isOpen = isOpen;
+    }
+  });
+  return conn;
 };
 
 var createTestStore = function createTestStore() {
   var actions = [];
   return {
     actions: actions,
+    next: function next(action) {},
     dispatch: function dispatch(action) {
       actions.push(action);
     }
@@ -44,38 +72,35 @@ var setup = function setup() {
 
   var connection = options.connection || createTestConnection();
   var store = options.store || createTestStore();
-  var session = options.session || createTestSession();
-  var middleware = (0, _middleware2.default)(connection);
+  var middleware = (0, _middleware2.default)({ connection: connection });
   var nextHandler = middleware(store);
 
   return {
     connection: connection,
     store: store,
-    session: session,
     middleware: middleware,
     nextHandler: nextHandler
   };
 };
 
 describe('middleware', function () {
-  it('throws an error when it is not given an autobahn.Connection', function () {
+  it('returns middleware when it is not given an autobahn.Connection', function () {
     expect(function () {
       return (0, _middleware2.default)();
-    }).toThrow('autobahn.Connection required');
+    }).toBeInstanceOf(Function);
   });
 
   describe('when the connection opens', function () {
     it('dispatches a CONNECTION_OPENED action with the given session', function () {
       var _setup = setup(),
           connection = _setup.connection,
-          store = _setup.store,
-          session = _setup.session;
+          store = _setup.store;
 
-      connection.onopen(session);
+      connection.onopen(connection.session);
 
       expect(store.actions).toEqual([{
         type: types.CONNECTION_OPENED,
-        session: session
+        session: connection.session
       }]);
     });
   });
@@ -84,10 +109,9 @@ describe('middleware', function () {
     it('dispatches a CONNECTION_CLOSED action', function () {
       var _setup2 = setup(),
           connection = _setup2.connection,
-          store = _setup2.store,
-          session = _setup2.session;
+          store = _setup2.store;
 
-      connection.onclose(session);
+      connection.onclose(connection.session);
 
       expect(store.actions).toEqual([{
         type: types.CONNECTION_CLOSED
@@ -100,18 +124,20 @@ describe('middleware', function () {
       it('dispatches a CONNECTED action', function () {
         var session = { id: 1, isOpen: true };
 
-        var _setup3 = setup({ session: session }),
+        var _setup3 = setup({
+          connection: createTestConnection({ session: session, isOpen: true })
+        }),
             connection = _setup3.connection,
             store = _setup3.store,
             nextHandler = _setup3.nextHandler;
 
-        connection.onopen(session);
+        connection.onopen(connection.session);
 
         nextHandler()(actionCreators.openConnection());
 
         expect(store.actions).toEqual([{
           type: types.CONNECTION_OPENED,
-          session: session
+          session: connection.session
         }, {
           type: types.CONNECTED
         }]);
@@ -141,12 +167,14 @@ describe('middleware', function () {
       it('dispatches a DISCONNECTED action', function () {
         var session = { id: 1, isOpen: false };
 
-        var _setup5 = setup({ session: session }),
+        var _setup5 = setup({
+          connection: createTestConnection({ session: session, isOpen: false })
+        }),
             connection = _setup5.connection,
             store = _setup5.store,
             nextHandler = _setup5.nextHandler;
 
-        connection.onclose(session);
+        connection.onclose(connection.session);
 
         nextHandler()(actionCreators.closeConnection());
 
@@ -161,22 +189,23 @@ describe('middleware', function () {
 
   describe('when it is connected', function () {
     it('calls close on the connection', function () {
-      var isClosed = false;
-      var connection = createTestConnection();
-      connection.close = function () {
-        isClosed = true;
-      };
-
       var session = { id: 1, isOpen: true };
 
-      var _setup6 = setup({ connection: connection, session: session }),
+      var _setup6 = setup({
+        connection: createTestConnection({ session: session, isOpen: true })
+      }),
+          connection = _setup6.connection,
           nextHandler = _setup6.nextHandler;
 
-      connection.onopen(session);
+      connection.close = function () {
+        connection.isOpen = false;
+      };
+
+      connection.onopen(connection.session);
 
       nextHandler()(actionCreators.closeConnection());
 
-      expect(isClosed).toEqual(true);
+      expect(connection.isOpen).toEqual(false);
     });
   });
 });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -28,12 +28,12 @@ const disconnected = () => ({
  * Returns a redux action with type CONNECTION_OPENED and the given session object
  * @function connectionOpened
  * @memberof redux-autobahn:middleware
- * @param {object} session - The session object for the opened connection.
+ * @param {object} connection - The object for the opened connection.
  * @return {object} redux action
  */
-const connectionOpened = session => ({
+const connectionOpened = connection => ({
   type: types.CONNECTION_OPENED,
-  session,
+  session: connection.session,
 });
 
 /**
@@ -220,13 +220,13 @@ const result = value => ({
 });
 
 /**
- * Returns a boolean that represents if the session exists and is open, therefore it is connected
+ * Returns a boolean that represents if the session for the connection exists and is open, therefore it is connected
  * @function isConnected
  * @memberof redux-autobahn:middleware
- * @param  {object} session  the session object
- * @return {boolean}         returns true if the session exists and is open
+ * @param  {object} connection  the connection object
+ * @return {boolean}         returns true if the session for the connection exists and is open
  */
-const isConnected = session => session && session.isOpen;
+const isConnected = connection => connection && connection.isOpen;
 
 /**
  * Returns the subscription from the action
@@ -242,22 +242,21 @@ const getSubscription = action => action.subscription;
  * @function handleAction
  * @memberof redux-autobahn:middleware
  * @param  {object} connection  the connection object
- * @param  {object} session     the session object
  * @param  {function} dispatch  the dispatch function
  * @param  {function} next      the next function
  * @param  {object} action      the redux action
  */
-const handleAction = (connection, session, dispatch, next, action) => {
+const handleAction = (connection, dispatch, next, action) => {
   switch (action.type) {
     case types.OPEN_CONNECTION:
-      return isConnected(session) ? dispatch(connected()) : connection.open();
+      return isConnected(connection) ? dispatch(connected()) : connection.open();
 
     case types.CLOSE_CONNECTION:
-      return !isConnected(session) ? dispatch(disconnected()) : connection.close();
+      return !isConnected(connection) ? dispatch(disconnected()) : connection.close();
 
     case types.SUBSCRIBE:
-      return !isConnected(session) ? dispatch(disconnected())
-        : session.subscribe(action.topic, (args, kwargs, details) => {
+      return !isConnected(connection) ? dispatch(disconnected())
+        : connection.session.subscribe(action.topic, (args, kwargs, details) => {
           dispatch(event(action.topic, args, kwargs, details));
         }).then((subscription) => {
           dispatch(subscribed(subscription));
@@ -266,8 +265,8 @@ const handleAction = (connection, session, dispatch, next, action) => {
         });
 
     case types.UNSUBSCRIBE:
-      return !isConnected(session) ? dispatch(disconnected())
-        : session.unsubscribe(getSubscription(action)).then((success) => {
+      return !isConnected(connection) ? dispatch(disconnected())
+        : connection.session.unsubscribe(getSubscription(action)).then((success) => {
           if (success) dispatch(unsubscribed(action.subscription));
           else unsubscribeError('Failed to unsubscribe');
         }, (err) => {
@@ -275,8 +274,8 @@ const handleAction = (connection, session, dispatch, next, action) => {
         });
 
     case types.PUBLISH:
-      return !isConnected(session) ? dispatch(disconnected())
-        : session.publish(action.topic, action.args, action.kwargs,
+      return !isConnected(connection) ? dispatch(disconnected())
+        : connection.session.publish(action.topic, action.args, action.kwargs,
           { ...action.options, acknowledge: true }).then((pub) => {
           dispatch(published(pub, action.topic, action.args, action.kwargs, action.options));
         }, (err) => {
@@ -284,24 +283,24 @@ const handleAction = (connection, session, dispatch, next, action) => {
         });
 
     case types.REGISTER:
-      return !isConnected(session) ? dispatch(disconnected())
-        : session.register(action.procedure, action.endpoint, action.options).then((reg) => {
+      return !isConnected(connection) ? dispatch(disconnected())
+        : connection.session.register(action.procedure, action.endpoint, action.options).then((reg) => {
           dispatch(registered(reg));
         }, (err) => {
           dispatch(registerError(err));
         });
 
     case types.UNREGISTER:
-      return !isConnected(session) ? dispatch(disconnected())
-        : session.unregister(action.registration).then(() => {
+      return !isConnected(connection) ? dispatch(disconnected())
+        : connection.session.unregister(action.registration).then(() => {
           dispatch(unregistered(action.registration));
         }, (err) => {
           dispatch(unregisterError(err));
         });
 
     case types.CALL:
-      return !isConnected(session) ? dispatch(disconnected())
-        : session.call(action.procedure, action.args, action.kwargs, action.options).then((res) => {
+      return !isConnected(connection) ? dispatch(disconnected())
+        : connection.session.call(action.procedure, action.args, action.kwargs, action.options).then((res) => {
           if (action.resultAction) {
             return dispatch(action.resultAction(res));
           }
@@ -332,9 +331,7 @@ const assert = (assertion, message) => {
   }
 };
 
-export default function autobahnMiddlewareFactory({ connection }) {
-  let connection = connection || null;
-  let session = null;
+export default function autobahnMiddlewareFactory({ connection } = {}) {
   function autobahnMiddleware({ dispatch }) {
     /**
      * Sets the passed connection for the middleware that dispatches opened and closed connection actions and handles actions
@@ -350,18 +347,17 @@ export default function autobahnMiddlewareFactory({ connection }) {
         'autobahn.Connection required'
       );
 
-      if (!autobahnMiddleware._connection) {
+      if (autobahnMiddleware._connection) {
         // close the existing connection
         autobahnMiddleware.closeConnection('newConnection', 'new connection has been set');
       }
 
       newConnection.onopen = (s) => {
-        session = s;
-        dispatch(connectionOpened(s));
+        dispatch(connectionOpened(newConnection));
       };
 
       newConnection.onclose = () => {
-        session = null;
+        autobahnMiddleware._connection = null;
         dispatch(connectionClosed());
       };
 
@@ -377,12 +373,12 @@ export default function autobahnMiddlewareFactory({ connection }) {
      */
     autobahnMiddleware.closeConnection = (reason, message) => {
       autobahnMiddleware.close(reason, message);
-      autobahnMiddleware._connection = null;
     };
 
+    if (connection) autobahnMiddleware.setConnection(connection);
+
     return next => action => {
-      if (!autobahnMiddleware._connection) return next(action);
-      handleAction(autobahnMiddleware._connection, session, dispatch, next, action);
+      handleAction(autobahnMiddleware._connection, dispatch, next, action);
     }
   }
 


### PR DESCRIPTION
https://github.com/brycedarling/redux-autobahn-js/issues/2
https://github.com/brycedarling/redux-autobahn-js/issues/7

I felt pretty bad for the immature code for the previous PR not only that it included some unnecessary code but also it broke the existing tests as well.

So I've worked a little more.

It'll be a breaking change since the creation of Middleware has been changed again.

1.
When you configure redux store,

if you want to set connection when creating middleware,
```
import createMiddleware from './middleware';
import { createStore } from `redux`;

// `connection` is optional
const autobahnMiddleware = createMiddleware({ connection });

const store = createStore();

store.setAutobahnConnection = autobahnMiddleware.setConnection;
store.closeAutobahnConnection = autobahnMiddleware.closeAutobahnConnection;
```

or

to set the connection later
```
import createMiddleware from './middleware';
import { createStore } from `redux`;

const autobahnMiddleware = createMiddleware();

const store = createStore();

store.setAutobahnConnection = autobahnMiddleware.setConnection;
store.closeAutobahnConnection = autobahnMiddleware.closeAutobahnConnection;
```
then uses the `store.setAutobahnConnection` later.

2. middleware is not passing `session` object around.
According to the autobahn.js API doc, `connection.session` is there for the current session of the connection.

3. `isConnected` checks for `Connection.isOpen` instead of `Session.isOpen`.
According to the autobahn.js API doc, they are pretty much the same thing.

** note that there is also `Connection.isConnected` for reading whether the connection itself is connected regardless of its session's status

* from autobahn.js doc
```
To get the session object if there is a session currently running over the connection:

Connection.session
which returns an instance of autobahn.Session if there is a session currently running on the connection.

To check whether the connection (the underlying transport for the session) has been established:

Connection.isConnected
which returns true if the Connection is open.

A read-only property that signals if the underlying session is open and attached to a realm:

Connection.isOpen
which returns true if the underlying session is open.
```