### PR TITLE
expose middleware functions correctly

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -345,55 +345,60 @@ const assert = (assertion, message) => {
 
 export default function autobahnMiddlewareFactory({ connection } = {}) {
   function autobahnMiddleware({ dispatch }) {
-    /**
-     * Sets the passed connection for the middleware that dispatches opened and closed connection actions and handles actions
-     * @function setConnection
-     * @memberof redux-autobahn:middleware
-     * @param  {Connection} newConnection  the connection object
-     */
-    autobahnMiddleware.setConnection = (newConnection) => {
-      assert(
-        newConnection &&
-          typeof newConnection.open === 'function' &&
-          typeof newConnection.close === 'function',
-        'autobahn.Connection required',
-      );
-
-      if (autobahnMiddleware._connection) {
-        // close the existing connection
-        autobahnMiddleware.closeConnection('newConnection', 'new connection has been set');
-      }
-
-      newConnection.onopen = (s) => {
-        dispatch(connectionOpened(newConnection));
-      };
-
-      newConnection.onclose = (reason, details) => {
-        autobahnMiddleware._connection = null;
-        dispatch(connectionClosed(reason, details));
-      };
-
-      autobahnMiddleware._connection = newConnection;
-    };
-
-    /**
-     * Closes the current autobahn connection
-     * @function closeConnection
-     * @memberof redux-autobahn:middleware
-     * @param  {string} reason  (optional) a WAMP URI providing a closing reason to the server side (e.g. 'com.myapp.close.signout'). default is `wamp.goodbye.normal`
-     * @param  {string} message  human-readable closing message
-     */
-    autobahnMiddleware.closeConnection = (reason, message) => {
-      if (isConnected(autobahnMiddleware._connection)) {
-        autobahnMiddleware._connection.close(reason, message);
-      }
-    };
-
-    if (connection) autobahnMiddleware.setConnection(connection);
+    autobahnMiddleware._dispatch = dispatch;
+    if (connection) {
+      autobahnMiddleware.setConnection(connection);
+      connection.open();
+    }
 
     return next => (action) => {
       handleAction(autobahnMiddleware._connection, dispatch, next, action);
     };
   }
+
+  /**
+   * Sets the passed connection for the middleware that dispatches opened and closed connection actions and handles actions
+   * @function setConnection
+   * @memberof redux-autobahn:middleware
+   * @param  {Connection} newConnection  the connection object
+   */
+  autobahnMiddleware.setConnection = (newConnection) => {
+    assert(
+      newConnection &&
+        typeof newConnection.open === 'function' &&
+        typeof newConnection.close === 'function',
+      'autobahn.Connection required',
+    );
+
+    if (autobahnMiddleware._connection) {
+      // close the existing connection
+      autobahnMiddleware.closeConnection('newConnection', 'new connection has been set');
+    }
+
+    newConnection.onopen = (s) => {
+      autobahnMiddleware._dispatch(connectionOpened(newConnection));
+    };
+
+    newConnection.onclose = (reason, details) => {
+      autobahnMiddleware._connection = null;
+      autobahnMiddleware._dispatch(connectionClosed(reason, details));
+    };
+
+    autobahnMiddleware._connection = newConnection;
+  };
+
+  /**
+   * Closes the current autobahn connection
+   * @function closeConnection
+   * @memberof redux-autobahn:middleware
+   * @param  {string} reason  (optional) a WAMP URI providing a closing reason to the server side (e.g. 'com.myapp.close.signout'). default is `wamp.goodbye.normal`
+   * @param  {string} message  human-readable closing message
+   */
+  autobahnMiddleware.closeConnection = (reason, message) => {
+    if (isConnected(autobahnMiddleware._connection)) {
+      autobahnMiddleware._connection.close(reason, message);
+    }
+  };
+
   return autobahnMiddleware;
 }


### PR DESCRIPTION
Pretty stupid and naive I was for not testing this correctly.

`setConnection` and `closeConnection` was meant to be exposed and be initialised before middleware is created..

below is example

```javascript
import { createStore, applyMiddleware, compose } from 'redux';
import { routerMiddleware } from 'react-router-redux';
import reduxAutobahn from 'redux-autobahn-js';
import autobahn from 'autobahn';
import createReducer from './reducers';

const sagaMiddleware = createSagaMiddleware();
const autobahnMiddleware = reduxAutobahn.middleware();


export default function configureStore(initialState = {}, history) {
  const middlewares = [
    sagaMiddleware,
    autobahnMiddleware,
    routerMiddleware(history),
  ];

  const enhancers = [
    applyMiddleware(...middlewares),
  ];


  const autobahnConnection = new autobahn.Connection({
    url: 'URL',
    realm: 'realm1',
    authmethods: ['wampcra'],
    authid: 'AUTH_ID',
    onchallenge: function (session, method, extra) {
       if (method === "wampcra") {
         return autobahn.auth_cra.sign('SECRET', extra.challenge);
       }
    },
  });

  autobahnMiddleware.setConnection(autobahnConnection);

  /*
  .
  .
  .
  */

  const store = createStore(
    fromJS(initialState),
    composeEnhancers(...enhancers)
  );

  return store;
}
```
or to set connection later
```javascript
const autobahnConnection = new autobahn.Connection({
  url: 'URL',
  realm: 'realm1',
  authmethods: ['wampcra'],
  authid: 'AUTH_ID',
  onchallenge: function (session, method, extra) {
     if (method === "wampcra") {
       return autobahn.auth_cra.sign('SECRET', extra.challenge);
     }
  },
});

autobahnMiddleware.setConnection(autobahnConnection);

store.dispatch(reduxAutobahn.actions.openConnection());
```